### PR TITLE
Add parent-child mapping generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repository organizes files used for managing Amazon orders. It is designed 
 - `orders/` – Past orders and new purchase orders.
 - `accessories/` – Packaging and accessory information, including accessory past orders.
 - `docs/` – Project notes and other documentation.
+- `docs/parent_child_mapping.json` – Machine-readable mapping of parent SKUs to
+  their child products. See `docs/parent_child_mapping.md` for details.
 - `images/` – Product related images used when generating order spreadsheets. It
   contains `products/`, `colors/`, and `logos/` subdirectories for the different
   image types.
@@ -20,3 +22,10 @@ Use `generate_order_template.py` with a JSON file that follows the
 structure documented in `docs/order_template.md` to create a purchase
 order spreadsheet. An example JSON file is provided in
 `docs/order_template_example.json`.
+
+## Order Rules
+
+- Each new order may contain only one parent product as defined in
+  `docs/parent_child_mapping.json`. When ordering child SKUs belonging to
+  different parents, create a separate spreadsheet for each parent product.
+

--- a/docs/parent_child_mapping.json
+++ b/docs/parent_child_mapping.json
@@ -1,0 +1,171 @@
+{
+  "parents": {
+    "B10-MJB2": {
+      "name": "木头脚挫2只装 Foot Scraper Pedicure Foot File, Professional Foot Rasp File Foot Scrubber, Premium Callus Remover for Feet to Remove Dead Skin, Hard Skin, Cracked Heels, Perfect Foot Care Pedicure Tools (2 Pack)",
+      "children": [
+        "B10-MJB2-BK",
+        "B10-MJB2-BK2"
+      ]
+    },
+    "B10-JMY802": {
+      "name": "洗脸仪",
+      "children": [
+        "B10-JMY802-BU",
+        "B10-JMY802-PK"
+      ]
+    },
+    "B10-MJQ1": {
+      "name": "电动磨脚器",
+      "children": [
+        "B10-MJQ1-BU",
+        "B10-MJQ1-PK"
+      ]
+    },
+    "B10-ZMS3D": {
+      "name": "bass同款",
+      "children": [
+        "B10-ZMS3D-BR",
+        "B10-ZMS3D-NEW"
+      ]
+    },
+    "B10-TJ2": {
+      "name": "金属支架12寸",
+      "children": [
+        "B10-TJ2-12",
+        "B10-TJ2-16",
+        "B10-TJ2-20"
+      ]
+    },
+    "FSC": {
+      "name": "FSC漂白榉木头梳（木针）",
+      "children": [
+        "FSC-WB01",
+        "FSC-WB02"
+      ]
+    },
+    "ST1122": {
+      "name": "norsewood棕黑色气垫梳8.5*24.5*1.3",
+      "children": [
+        "ST1122-1",
+        "ST1122-3"
+      ]
+    },
+    "EC403": {
+      "name": "Ecoed咖啡渣浴刷",
+      "children": [
+        "EC403",
+        "EC403-2",
+        "EC403-3"
+      ]
+    },
+    "EC": {
+      "name": "ECOED粉色指甲钳套装新22",
+      "children": [
+        "EC-5001",
+        "EC-ZZ01"
+      ]
+    },
+    "EC04": {
+      "name": "化妆刷套装GREEN",
+      "children": [
+        "EC04-GREEN",
+        "EC04-NATURAL"
+      ]
+    },
+    "EC-D1": {
+      "name": "化妆刷大头 PINK",
+      "children": [
+        "EC-D1-PINK",
+        "EC-D1-GREEN",
+        "EC-D1-NATURAL",
+        "EC-D1-CYAN"
+      ]
+    },
+    "EC-P3": {
+      "name": "化妆刷平头PINK",
+      "children": [
+        "EC-P3-PINK",
+        "EC-P3-GREEN",
+        "EC-P3-NATURAL",
+        "EC-P3-CYAN"
+      ]
+    },
+    "EC-X2": {
+      "name": "化妆刷斜头PINK",
+      "children": [
+        "EC-X2-PINK",
+        "EC-X2-GREEN",
+        "EC-X2-NATURAL",
+        "EC-X2-CYAN"
+      ]
+    },
+    "2EC": {
+      "name": "Ecoed洗头刷粉色两只装细针",
+      "children": [
+        "2EC-Pink",
+        "2EC-Blue",
+        "2EC-Green",
+        "2EC-Yellow"
+      ]
+    },
+    "BB101": {
+      "name": "boxxbrush盒子梳玫红色",
+      "children": [
+        "BB101-2",
+        "BB101-3"
+      ]
+    },
+    "EC405-1": {
+      "name": "ecoed 洗头刷405单只装蓝色粗针",
+      "children": [
+        "EC405-1-Blue",
+        "EC405-1-Green",
+        "EC405-1-Pink",
+        "EC405-1-Grey"
+      ]
+    },
+    "EC405-2": {
+      "name": "ecoed 洗头刷405两只装蓝色粗针",
+      "children": [
+        "EC405-2-Blue",
+        "EC405-2-Green",
+        "EC405-2-Pink",
+        "EC405-2-Grey"
+      ]
+    },
+    "EC405-3": {
+      "name": "ecoed 洗头刷405单只装蓝色50硬",
+      "children": [
+        "EC405-3-Blue",
+        "EC405-3-Green",
+        "EC405-3-Pink",
+        "EC405-3-Grey"
+      ]
+    },
+    "ECSB": {
+      "name": "Ecoed洗头刷绿色组合装",
+      "children": [
+        "ECSB-2Green",
+        "ECSB-2Blue",
+        "ECSB-TPR1"
+      ]
+    },
+    "NW": {
+      "name": "norsewood灰色榉木气垫猪鬃梳（bass）",
+      "children": [
+        "NW-GRAY1",
+        "NW-GRAY2",
+        "NW-GRAY3"
+      ]
+    },
+    "AMCB": {
+      "name": "尼龙卷发定型梳(蓝色)",
+      "children": [
+        "AMCB-black",
+        "AMCB-Pink",
+        "AMCB-Blue",
+        "AMCB-01"
+      ]
+    }
+  }
+}

--- a/docs/parent_child_mapping.md
+++ b/docs/parent_child_mapping.md
@@ -1,0 +1,24 @@
+# Parent and Child Products
+
+Some products have very similar names and share the same accessories. These relationships were identified from the spreadsheet `导出产品-按SKU-808264991961878528.xlsx` and are documented here so that accessory requirements can be grouped by parent product.
+
+## JSON Structure
+
+```json
+{
+  "parents": {
+    "<parent_sku>": {
+      "name": "<parent_name>",
+      "children": ["<child_sku1>", "<child_sku2>", ...]
+    },
+    ...
+  }
+}
+```
+
+For example, the parent SKU `B10-MJB2` groups the two child SKUs `B10-MJB2-BK` and `B10-MJB2-BK2`. They use the same accessory SKU listed in `accessory_mapping.json`.
+
+The actual relationships are stored in `parent_child_mapping.json` in this
+directory. This file is generated from the spreadsheet and used by automation
+scripts.
+

--- a/excel_to_json.py
+++ b/excel_to_json.py
@@ -25,6 +25,10 @@ def read_rows(path: str) -> List[List[str]]:
                 val = ''
                 if v is not None:
                     val = shared[int(v.text)] if t == 's' else v.text
+                elif t == 'inlineStr':
+                    is_elem = c.find(NAMESPACE + 'is')
+                    if is_elem is not None:
+                        val = ''.join(tel.text or '' for tel in is_elem.findall('.//' + NAMESPACE + 't'))
                 cells.append(val if val is not None else '')
             rows.append(cells)
         return rows

--- a/generate_parent_child_mapping.py
+++ b/generate_parent_child_mapping.py
@@ -1,0 +1,48 @@
+import json
+import sys
+from typing import Dict, Any
+from excel_to_json import read_rows
+
+
+def build_mapping(xlsx: str) -> Dict[str, Any]:
+    rows = read_rows(xlsx)
+    if not rows:
+        return {"parents": {}}
+    header = rows[0]
+    try:
+        sku_idx = header.index('*SKU')
+    except ValueError:
+        raise ValueError('SKU column "*SKU" not found')
+    name_idx = header.index('品名') if '品名' in header else None
+    mapping: Dict[str, Dict[str, Any]] = {}
+    for row in rows[1:]:
+        if sku_idx >= len(row):
+            continue
+        sku = row[sku_idx].strip()
+        if not sku:
+            continue
+        name = row[name_idx].strip() if name_idx is not None and name_idx < len(row) else ''
+        if '-' in sku:
+            parent = sku.rsplit('-', 1)[0]
+        else:
+            parent = sku
+        entry = mapping.setdefault(parent, {"name": name, "children": []})
+        if not entry["name"]:
+            entry["name"] = name
+        entry["children"].append(sku)
+    mapping = {p: v for p, v in mapping.items() if len(v["children"]) > 1}
+    return {"parents": mapping}
+
+
+def main():
+    if len(sys.argv) != 3:
+        print('usage: generate_parent_child_mapping.py <input.xlsx> <output.json>')
+        return 1
+    mapping = build_mapping(sys.argv[1])
+    with open(sys.argv[2], 'w', encoding='utf-8') as f:
+        json.dump(mapping, f, ensure_ascii=False, indent=2)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add script `generate_parent_child_mapping.py` to build parent→child SKU JSON
- extend `excel_to_json.read_rows` to read inline strings from Excel files
- generate `docs/parent_child_mapping.json` from the export spreadsheet
- update documentation and README to reference the JSON mapping

## Testing
- `python -m py_compile generate_order_template.py excel_to_json.py generate_parent_child_mapping.py`


------
https://chatgpt.com/codex/tasks/task_b_6886e01f5330832fafceb3b78bc5b000