### PR TITLE
Update mapping with in-stock SKUs

### DIFF
--- a/order_generation/docs/complete_mapping.json
+++ b/order_generation/docs/complete_mapping.json
@@ -921,6 +921,254 @@
           "accessories": []
         }
       ]
+    },
+    "B10-GTS2-4JZ-BK": {
+      "name": "黑色铝筒",
+      "children": [
+        {
+          "sku": "B10-GTS2-4JZ-BK",
+          "name": "黑色铝筒",
+          "accessories": [
+            {
+              "sku": "US-BR01-02",
+              "name": "发夹",
+              "ratio_main": "1",
+              "ratio_accessory": "4"
+            },
+            {
+              "sku": "B10-GTS2-4JZ-BK-1",
+              "name": "AM800黑色铝筒包装",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "B10-GTS2-4JZ-BK-3",
+              "name": "am800金色铝筒子配件发夹夹板",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "Elasticbrush02": {
+      "name": "ecoed 可降解黄色鱼骨梳",
+      "children": [
+        {
+          "sku": "Elasticbrush02",
+          "name": "ecoed 可降解黄色鱼骨梳",
+          "accessories": [
+            {
+              "sku": "EC221-2-1",
+              "name": "ecoed鱼骨梳包装2.0黄",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "Elasticbrush06": {
+      "name": "ecoed 可降解粉色鱼骨梳",
+      "children": [
+        {
+          "sku": "Elasticbrush06",
+          "name": "ecoed 可降解粉色鱼骨梳",
+          "accessories": [
+            {
+              "sku": "EC221-4-1",
+              "name": "ecoed鱼骨梳包装2.0粉",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "EC404": {
+      "name": "Ecoed洗头刷绿色单只装细针",
+      "children": [
+        {
+          "sku": "EC404",
+          "name": "Ecoed洗头刷绿色单只装细针",
+          "accessories": [
+            {
+              "sku": "EC401-3",
+              "name": "ecoed发泡带洗头刷用",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "EC404-1-10-3",
+              "name": "洗头刷包装绿色细针单只",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "48-82P3-QSFG": {
+      "name": "BASS新款胡子梳",
+      "children": [
+        {
+          "sku": "48-82P3-QSFG",
+          "name": "BASS新款胡子梳",
+          "accessories": [
+            {
+              "sku": "US-RB01-01",
+              "name": "norsewood清洁刷子木",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "SSD",
+              "name": "norsewood鹿皮绒收缩袋",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "ST1122-1-2",
+              "name": "norsewood 方头猪鬃梳包装",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "ST1122-5",
+              "name": "norsewood爪子刷 猪鬃梳",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "7S-HA5T-5D0X": {
+      "name": "Ecoed洗头刷原色单只装细针",
+      "children": [
+        {
+          "sku": "7S-HA5T-5D0X",
+          "name": "Ecoed洗头刷原色单只装细针",
+          "accessories": [
+            {
+              "sku": "EC401-3",
+              "name": "ecoed发泡带洗头刷用",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "EC404-2-4",
+              "name": "洗头刷包装原色细针单只",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "ZW-YI7D-KWFL": {
+      "name": "Ecoed洗头刷蓝色单只装细针",
+      "children": [
+        {
+          "sku": "ZW-YI7D-KWFL",
+          "name": "Ecoed洗头刷蓝色单只装细针",
+          "accessories": [
+            {
+              "sku": "EC401-3",
+              "name": "ecoed发泡带洗头刷用",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "EC404-2-2",
+              "name": "洗头刷包装蓝色细针单只",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "ZQ-R8SK-ROL2": {
+      "name": "金色陶瓷漆圆桶刷2.1&1.3in",
+      "children": [
+        {
+          "sku": "ZQ-R8SK-ROL2",
+          "name": "金色陶瓷漆圆桶刷2.1&1.3in",
+          "accessories": [
+            {
+              "sku": "EE1.3#2.1-1",
+              "name": "EE1.3&2.1 铝桶包装烫金",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "EERB-FJ",
+              "name": "金色铝筒发夹",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "EX-1L2K-CN3N": {
+      "name": "卷发通风梳",
+      "children": [
+        {
+          "sku": "EX-1L2K-CN3N",
+          "name": "卷发通风梳",
+          "accessories": [
+            {
+              "sku": "EX-1L2K-CN3N-1",
+              "name": "蜂窝梳包装",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "EEHB-NBB": {
+      "name": "黑红猪鬃气垫梳",
+      "children": [
+        {
+          "sku": "EEHB-NBB",
+          "name": "黑红猪鬃气垫梳",
+          "accessories": [
+            {
+              "sku": "EEHB-NBB-1C",
+              "name": "咖啡色发绳",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "EEHB-NBB-1B",
+              "name": "黑色发绳",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "EEHB-NBB-2",
+              "name": "黑色棘皮绒",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "EEHB-NBB-3",
+              "name": "猪鬃梳天地盖礼盒",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "EEHB-NBB-4",
+              "name": "黑红猪鬃清洁刷",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/order_generation/docs/complete_mapping_with_po.json
+++ b/order_generation/docs/complete_mapping_with_po.json
@@ -1059,6 +1059,315 @@
           "accessories": []
         }
       ]
+    },
+    "B10-GTS2-4JZ-BK": {
+      "name": "黑色铝筒",
+      "children": [
+        {
+          "sku": "B10-GTS2-4JZ-BK",
+          "name": "黑色铝筒",
+          "accessories": [
+            {
+              "sku": "US-BR01-02",
+              "name": "发夹",
+              "ratio_main": "1",
+              "ratio_accessory": "4",
+              "purchase_order": "24AM038-1",
+              "purchase_order_file": "24AM035(1).xlsx"
+            },
+            {
+              "sku": "B10-GTS2-4JZ-BK-1",
+              "name": "AM800黑色铝筒包装",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "24AM038-2",
+              "purchase_order_file": "24AM034-1(1).xlsx"
+            },
+            {
+              "sku": "B10-GTS2-4JZ-BK-3",
+              "name": "am800金色铝筒子配件发夹夹板",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "24AM038-3",
+              "purchase_order_file": "24AM031-QF.xlsx"
+            }
+          ],
+          "purchase_order": "PO250401002",
+          "purchase_order_file": "24AM038-QFAM8.00金色铝筒.xlsx"
+        }
+      ]
+    },
+    "Elasticbrush02": {
+      "name": "ecoed 可降解黄色鱼骨梳",
+      "children": [
+        {
+          "sku": "Elasticbrush02",
+          "name": "ecoed 可降解黄色鱼骨梳",
+          "accessories": [
+            {
+              "sku": "EC221-2-1",
+              "name": "ecoed鱼骨梳包装2.0黄",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "23AM002-KY"
+            }
+          ],
+          "purchase_order": "PO240510001",
+          "purchase_order_file": "23AM068-JX (6).xlsx"
+        }
+      ]
+    },
+    "Elasticbrush06": {
+      "name": "ecoed 可降解粉色鱼骨梳",
+      "children": [
+        {
+          "sku": "Elasticbrush06",
+          "name": "ecoed 可降解粉色鱼骨梳",
+          "accessories": [
+            {
+              "sku": "EC221-4-1",
+              "name": "ecoed鱼骨梳包装2.0粉",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "24AM024-1"
+            }
+          ],
+          "purchase_order": "24AM024-JX",
+          "purchase_order_file": "24AM024-JX 粉色鱼骨梳.xlsx"
+        }
+      ]
+    },
+    "EC404": {
+      "name": "Ecoed洗头刷绿色单只装细针",
+      "children": [
+        {
+          "sku": "EC404",
+          "name": "Ecoed洗头刷绿色单只装细针",
+          "accessories": [
+            {
+              "sku": "EC401-3",
+              "name": "ecoed发泡带洗头刷用",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM004-JY",
+              "purchase_order_file": "25AM004-JY.xlsx"
+            },
+            {
+              "sku": "EC404-1-10-3",
+              "name": "洗头刷包装绿色细针单只",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM012-1",
+              "purchase_order_file": "25AM012-1.xlsx"
+            }
+          ],
+          "purchase_order": "25AM012",
+          "purchase_order_file": "修改单25AM012.xlsx"
+        }
+      ]
+    },
+    "48-82P3-QSFG": {
+      "name": "BASS新款胡子梳",
+      "children": [
+        {
+          "sku": "48-82P3-QSFG",
+          "name": "BASS新款胡子梳",
+          "accessories": [
+            {
+              "sku": "US-RB01-01",
+              "name": "norsewood清洁刷子木",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM007-3",
+              "purchase_order_file": "25AM007-3.xlsx"
+            },
+            {
+              "sku": "SSD",
+              "name": "norsewood鹿皮绒收缩袋",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM007-1-YL",
+              "purchase_order_file": "25AM007-1-YL.xlsx"
+            },
+            {
+              "sku": "ST1122-1-2",
+              "name": "norsewood 方头猪鬃梳包装",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM003-2",
+              "purchase_order_file": "25AM003-2.xlsx"
+            },
+            {
+              "sku": "ST1122-5",
+              "name": "norsewood爪子刷 猪鬃梳",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "PO250612001"
+            }
+          ],
+          "purchase_order": "PO240527001"
+        }
+      ]
+    },
+    "7S-HA5T-5D0X": {
+      "name": "Ecoed洗头刷原色单只装细针",
+      "children": [
+        {
+          "sku": "7S-HA5T-5D0X",
+          "name": "Ecoed洗头刷原色单只装细针",
+          "accessories": [
+            {
+              "sku": "EC401-3",
+              "name": "ecoed发泡带洗头刷用",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM004-JY",
+              "purchase_order_file": "25AM004-JY.xlsx"
+            },
+            {
+              "sku": "EC404-2-4",
+              "name": "洗头刷包装原色细针单只",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "23AM075-KY"
+            }
+          ],
+          "purchase_order": "PO240625004",
+          "purchase_order_file": "23AM073-JX  (1).xlsx"
+        }
+      ]
+    },
+    "ZW-YI7D-KWFL": {
+      "name": "Ecoed洗头刷蓝色单只装细针",
+      "children": [
+        {
+          "sku": "ZW-YI7D-KWFL",
+          "name": "Ecoed洗头刷蓝色单只装细针",
+          "accessories": [
+            {
+              "sku": "EC401-3",
+              "name": "ecoed发泡带洗头刷用",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM004-JY",
+              "purchase_order_file": "25AM004-JY.xlsx"
+            },
+            {
+              "sku": "EC404-2-2",
+              "name": "洗头刷包装蓝色细针单只",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM017-1",
+              "purchase_order_file": "副本25AM017-1.xlsx"
+            }
+          ],
+          "purchase_order": "PO240625003",
+          "purchase_order_file": "23AM073-JX  (1).xlsx"
+        }
+      ]
+    },
+    "ZQ-R8SK-ROL2": {
+      "name": "金色陶瓷漆圆桶刷2.1&1.3in",
+      "children": [
+        {
+          "sku": "ZQ-R8SK-ROL2",
+          "name": "金色陶瓷漆圆桶刷2.1&1.3in",
+          "accessories": [
+            {
+              "sku": "EE1.3#2.1-1",
+              "name": "EE1.3&2.1 铝桶包装烫金",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM006-2",
+              "purchase_order_file": "25AM006-2(1).xlsx"
+            },
+            {
+              "sku": "EERB-FJ",
+              "name": "金色铝筒发夹",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM006-1",
+              "purchase_order_file": "25AM006-1.xlsx"
+            }
+          ],
+          "purchase_order": "PO250401001",
+          "purchase_order_file": "24AM026-JX(1).xlsx"
+        }
+      ]
+    },
+    "EX-1L2K-CN3N": {
+      "name": "卷发通风梳",
+      "children": [
+        {
+          "sku": "EX-1L2K-CN3N",
+          "name": "卷发通风梳",
+          "accessories": [
+            {
+              "sku": "EX-1L2K-CN3N-1",
+              "name": "蜂窝梳包装",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "24AM036-1-JX",
+              "purchase_order_file": "清洁刷24AM037-5(1).xlsx"
+            }
+          ],
+          "purchase_order": "24AM036-JX",
+          "purchase_order_file": "副本24AM036-JX.xlsx"
+        }
+      ]
+    },
+    "EEHB-NBB": {
+      "name": "黑红猪鬃气垫梳",
+      "children": [
+        {
+          "sku": "EEHB-NBB",
+          "name": "黑红猪鬃气垫梳",
+          "accessories": [
+            {
+              "sku": "EEHB-NBB-1C",
+              "name": "咖啡色发绳",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM002-1",
+              "purchase_order_file": "25AM002-1.xlsx"
+            },
+            {
+              "sku": "EEHB-NBB-1B",
+              "name": "黑色发绳",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM002-1",
+              "purchase_order_file": "25AM002-1.xlsx"
+            },
+            {
+              "sku": "EEHB-NBB-2",
+              "name": "黑色棘皮绒",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM002-2",
+              "purchase_order_file": "25AM002-2.xlsx"
+            },
+            {
+              "sku": "EEHB-NBB-3",
+              "name": "猪鬃梳天地盖礼盒",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM002-3",
+              "purchase_order_file": "25AM002-3.xlsx"
+            },
+            {
+              "sku": "EEHB-NBB-4",
+              "name": "黑红猪鬃清洁刷",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM007-4",
+              "purchase_order_file": "25AM007-4.xlsx"
+            }
+          ],
+          "purchase_order": "25AM002",
+          "purchase_order_file": "副本修改单25AM002.xlsx"
+        }
+      ]
     }
   }
 }

--- a/order_generation/excel_to_json.py
+++ b/order_generation/excel_to_json.py
@@ -68,10 +68,17 @@ def read_workbook(path: str) -> Dict[str, Tuple[str, str, str]]:
         for c in sheet_root.findall('.//' + NAMESPACE + 'c'):
             addr = c.get('r')
             t = c.get('t')
-            v = c.find(NAMESPACE + 'v')
             val = ''
-            if v is not None:
-                val = shared[int(v.text)] if t == 's' else v.text
+            if t == 'inlineStr':
+                is_elem = c.find(NAMESPACE + 'is')
+                if is_elem is not None:
+                    t_elem = is_elem.find(NAMESPACE + 't')
+                    if t_elem is not None:
+                        val = t_elem.text or ''
+            else:
+                v = c.find(NAMESPACE + 'v')
+                if v is not None:
+                    val = shared[int(v.text)] if t == 's' else v.text
             f = c.find(NAMESPACE + 'f')
             formula = f.text if f is not None else None
             color = None


### PR DESCRIPTION
## Summary
- parse Excel inline strings correctly
- extend complete mapping with products that have stock but were missing
- regenerate purchase order details for the updated mapping

## Testing
- `python -m py_compile add_purchase_orders.py merge_mappings.py order_generation/excel_to_json.py order_generation/advanced_excel_to_json.py`

------
https://chatgpt.com/codex/tasks/task_b_68887940369c832fb7cd692078d85600