### PR TITLE
Add missing SKUs with inventory

### DIFF
--- a/order_generation/docs/complete_mapping.json
+++ b/order_generation/docs/complete_mapping.json
@@ -1169,6 +1169,132 @@
           ]
         }
       ]
+    },
+    "Elasticbrush01": {
+      "name": "ecoed 可降解绿色鱼骨梳",
+      "children": [
+        {
+          "sku": "Elasticbrush01",
+          "name": "ecoed 可降解绿色鱼骨梳",
+          "accessories": [
+            {
+              "sku": "EC221-1-1",
+              "name": "ecoed鱼骨梳包装2.0绿",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "Elasticbrush05": {
+      "name": "ecoed 可降解蓝色鱼骨梳",
+      "children": [
+        {
+          "sku": "Elasticbrush05",
+          "name": "ecoed 可降解蓝色鱼骨梳",
+          "accessories": [
+            {
+              "sku": "EC221-3-1",
+              "name": "ecoed鱼骨梳包装2.0蓝",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "EERB2.11.3": {
+      "name": "ellen evyse黑色弹性漆铝筒2只装2.1/1.3in",
+      "children": [
+        {
+          "sku": "EERB2.11.3",
+          "name": "ellen evyse黑色弹性漆铝筒2只装2.1/1.3in",
+          "accessories": [
+            {
+              "sku": "EYJ",
+              "name": "鳄鱼夹",
+              "ratio_main": "1",
+              "ratio_accessory": "2"
+            },
+            {
+              "sku": "EE1101-1-2",
+              "name": "鳄鱼夹板，双面印刷",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "EE1.3#2.1-1",
+              "name": "EE1.3&2.1 铝桶包装烫金",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "17-A1KN-KJGW": {
+      "name": "黑人卷发定型梳(蓝色)",
+      "children": [
+        {
+          "sku": "17-A1KN-KJGW",
+          "name": "黑人卷发定型梳(蓝色)",
+          "accessories": [
+            {
+              "sku": "17-A1KN-KJGW-1",
+              "name": "黑人卷发梳包装",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "AMSC-green": {
+      "name": "卷发梳睡帽套装",
+      "children": [
+        {
+          "sku": "AMSC-green",
+          "name": "卷发梳睡帽套装",
+          "accessories": [
+            {
+              "sku": "AMSC-green-1",
+              "name": "卷发梳睡帽包装",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "SM-01",
+              "name": "睡帽",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "EE-RB-1.32.1": {
+      "name": "玫瑰金圆桶刷2.1&1.3in",
+      "children": [
+        {
+          "sku": "EE-RB-1.32.1",
+          "name": "玫瑰金圆桶刷2.1&1.3in",
+          "accessories": [
+            {
+              "sku": "EE1.3#2.1-1",
+              "name": "EE1.3&2.1 铝桶包装烫金",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            },
+            {
+              "sku": "EERB-FJ",
+              "name": "金色铝筒发夹",
+              "ratio_main": "1",
+              "ratio_accessory": "1"
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/order_generation/docs/complete_mapping_with_po.json
+++ b/order_generation/docs/complete_mapping_with_po.json
@@ -1368,6 +1368,160 @@
           "purchase_order_file": "副本修改单25AM002.xlsx"
         }
       ]
+    },
+    "Elasticbrush01": {
+      "name": "ecoed 可降解绿色鱼骨梳",
+      "children": [
+        {
+          "sku": "Elasticbrush01",
+          "name": "ecoed 可降解绿色鱼骨梳",
+          "accessories": [
+            {
+              "sku": "EC221-1-1",
+              "name": "ecoed鱼骨梳包装2.0绿",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM014-1",
+              "purchase_order_file": "25AM014-1.xlsx"
+            }
+          ],
+          "purchase_order": "PO250529002",
+          "purchase_order_file": "副本25AM010(1).xlsx"
+        }
+      ]
+    },
+    "Elasticbrush05": {
+      "name": "ecoed 可降解蓝色鱼骨梳",
+      "children": [
+        {
+          "sku": "Elasticbrush05",
+          "name": "ecoed 可降解蓝色鱼骨梳",
+          "accessories": [
+            {
+              "sku": "EC221-3-1",
+              "name": "ecoed鱼骨梳包装2.0蓝",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "23AM076-KY"
+            }
+          ],
+          "purchase_order": "PO250701003",
+          "purchase_order_file": "副本25AM010(1).xlsx"
+        }
+      ]
+    },
+    "EERB2.11.3": {
+      "name": "ellen evyse黑色弹性漆铝筒2只装2.1/1.3in",
+      "children": [
+        {
+          "sku": "EERB2.11.3",
+          "name": "ellen evyse黑色弹性漆铝筒2只装2.1/1.3in",
+          "accessories": [
+            {
+              "sku": "EYJ",
+              "name": "鳄鱼夹",
+              "ratio_main": "1",
+              "ratio_accessory": "2",
+              "purchase_order": "24AM026-1"
+            },
+            {
+              "sku": "EE1101-1-2",
+              "name": "鳄鱼夹板，双面印刷",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "24AM026-2",
+              "purchase_order_file": "24AM026-2.xlsx"
+            },
+            {
+              "sku": "EE1.3#2.1-1",
+              "name": "EE1.3&2.1 铝桶包装烫金",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM006-2",
+              "purchase_order_file": "25AM006-2(1).xlsx"
+            }
+          ],
+          "purchase_order": "JX22061601-3",
+          "purchase_order_file": "JX22061601(1) (1).xlsx"
+        }
+      ]
+    },
+    "17-A1KN-KJGW": {
+      "name": "黑人卷发定型梳(蓝色)",
+      "children": [
+        {
+          "sku": "17-A1KN-KJGW",
+          "name": "黑人卷发定型梳(蓝色)",
+          "accessories": [
+            {
+              "sku": "17-A1KN-KJGW-1",
+              "name": "黑人卷发梳包装",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM013-1",
+              "purchase_order_file": "25AM013-1.xlsx"
+            }
+          ],
+          "purchase_order": "24AM044",
+          "purchase_order_file": "24AM044-QF - 副本.xlsx"
+        }
+      ]
+    },
+    "AMSC-green": {
+      "name": "卷发梳睡帽套装",
+      "children": [
+        {
+          "sku": "AMSC-green",
+          "name": "卷发梳睡帽套装",
+          "accessories": [
+            {
+              "sku": "AMSC-green-1",
+              "name": "卷发梳睡帽包装",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "24AM044-1",
+              "purchase_order_file": "FD-24AM044-1.xlsx"
+            },
+            {
+              "sku": "SM-01",
+              "name": "睡帽",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "24AM048"
+            }
+          ],
+          "purchase_order": "PO241231001"
+        }
+      ]
+    },
+    "EE-RB-1.32.1": {
+      "name": "玫瑰金圆桶刷2.1&1.3in",
+      "children": [
+        {
+          "sku": "EE-RB-1.32.1",
+          "name": "玫瑰金圆桶刷2.1&1.3in",
+          "accessories": [
+            {
+              "sku": "EE1.3#2.1-1",
+              "name": "EE1.3&2.1 铝桶包装烫金",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM006-2",
+              "purchase_order_file": "25AM006-2(1).xlsx"
+            },
+            {
+              "sku": "EERB-FJ",
+              "name": "金色铝筒发夹",
+              "ratio_main": "1",
+              "ratio_accessory": "1",
+              "purchase_order": "25AM006-1",
+              "purchase_order_file": "25AM006-1.xlsx"
+            }
+          ],
+          "purchase_order": "25AM006",
+          "purchase_order_file": "金色铝桶返单25AM006-JX.xlsx"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- include SKUs with stock from inventory workbook in `complete_mapping.json`
- regenerate `complete_mapping_with_po.json` with purchase order info

## Testing
- `python add_purchase_orders.py`
- `python -m py_compile add_purchase_orders.py merge_mappings.py order_generation/*.py`

------
https://chatgpt.com/codex/tasks/task_b_68887bbc9ffc832f9232842940fd0156