### PR TITLE
Add JSON-based PO Excel generator

### DIFF
--- a/PO_excel.py
+++ b/PO_excel.py
@@ -1,0 +1,129 @@
+import json
+from typing import Dict, Any, List
+from openpyxl import load_workbook
+from openpyxl.drawing.image import Image as XLImage
+from openpyxl.utils import column_index_from_string, get_column_letter
+
+START_ROW = 7  # first product row in the template
+PLACEHOLDER_ROWS = 3  # number of placeholder product rows in the template
+BUYER_ROW = 69  # base row for buyer name (before any inserted rows)
+
+def validate_cells(ws, cells: Dict[str, Any]) -> None:
+    """Ensure every address exists and its label matches the JSON ``key``.
+
+    The JSON ``cells`` mapping stores entries like ``{"B3": {"key": "供货商：", "value": "..."}}``.
+    The value for ``key`` is expected to match the text in either the target cell
+    or the cell to its immediate left.  A ``ValueError`` is raised if a mismatch
+    is found so the template can be updated before continuing.
+    """
+    for address, meta in cells.items():
+        # Make sure the address is valid
+        try:
+            cell = ws[address]
+        except ValueError as exc:
+            raise ValueError(f"Invalid cell address '{address}' in JSON") from exc
+
+        if not isinstance(meta, dict):
+            continue
+        key = meta.get("key")
+        if not key:
+            continue
+
+        # First check the cell itself
+        if cell.value == key:
+            continue
+
+        # Then check the cell to the left if possible
+        col_letters = ''.join(filter(str.isalpha, address))
+        row_numbers = ''.join(filter(str.isdigit, address))
+        col_idx = column_index_from_string(col_letters)
+        if col_idx > 1:
+            left_addr = f"{get_column_letter(col_idx - 1)}{row_numbers}"
+            if ws[left_addr].value == key:
+                continue
+        # Neither cell matched; raise an error
+        raise ValueError(
+            f"Key '{key}' for cell '{address}' does not match template (found '{cell.value}')."
+        )
+
+def fill_cells(ws, cells: Dict[str, Any]) -> None:
+    """Write values from the JSON ``cells`` mapping into the worksheet."""
+    validate_cells(ws, cells)
+    for address, meta in cells.items():
+        value = meta.get("value") if isinstance(meta, dict) else meta
+        ws[address] = value
+
+def insert_products(ws, products: List[Dict[str, Any]]) -> int:
+    """Insert product rows into the worksheet starting at ``START_ROW``.
+
+    Returns the number of rows inserted which is used to adjust footer
+    positions below the product table.
+    """
+    extra = max(0, len(products) - PLACEHOLDER_ROWS)
+    if extra:
+        ws.insert_rows(START_ROW + PLACEHOLDER_ROWS, extra)
+
+    row_count = max(len(products), PLACEHOLDER_ROWS)
+    for idx in range(row_count):
+        r = START_ROW + idx
+        item = products[idx] if idx < len(products) else {}
+        ws.cell(row=r, column=1, value=item.get("产品编号", ""))
+        img_path = item.get("产品图片")
+        if img_path:
+            try:
+                ws.add_image(XLImage(img_path), f"B{r}")
+            except Exception:
+                # If the image can't be loaded, fall back to writing the path
+                ws.cell(row=r, column=2, value=img_path)
+        else:
+            ws.cell(row=r, column=2, value="")
+        name = item.get("产品名称", "").strip()
+        desc = item.get("描述", "").strip()
+        if name:
+            desc = f"{name} {desc}" if desc else name
+        ws.cell(row=r, column=3, value=desc)
+        ws.cell(row=r, column=4, value=item.get("数量/个", ""))
+        ws.cell(row=r, column=5, value=item.get("单价", ""))
+        ws.cell(row=r, column=6, value=f"=E{r}*D{r}")
+        ws.cell(row=r, column=7, value=item.get("包装方式", ""))
+
+    total_row = START_ROW + row_count
+    ws.cell(row=total_row, column=4, value=f"=SUM(D{START_ROW}:D{total_row-1})")
+    ws.cell(row=total_row, column=6, value=f"=SUM(F{START_ROW}:F{total_row-1})")
+    return extra
+
+def create_order_workbook(data: Dict[str, Any], template: str, output: str) -> None:
+    wb = load_workbook(template)
+    ws = wb.active
+
+    fill_cells(ws, data.get("cells", {}))
+    offset = insert_products(ws, data.get("products", []))
+
+    footer = data.get("footer", {})
+    if footer:
+        buyer_cell = f"B{BUYER_ROW + offset}"
+        supplier_cell = f"E{BUYER_ROW + offset}"
+        if "buyer" in footer:
+            ws[buyer_cell] = footer["buyer"]
+        if "supplier" in footer:
+            ws[supplier_cell] = footer["supplier"]
+
+    wb.save(output)
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Fill purchase order template spreadsheet")
+    parser.add_argument("json", help="Path to order data json")
+    parser.add_argument("output", help="Output Excel file path")
+    parser.add_argument(
+        "--template",
+        default="order_generation/docs/empty_base_template.xlsx",
+        help="Template workbook path",
+    )
+    args = parser.parse_args()
+
+    with open(args.json, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    create_order_workbook(data, args.template, args.output)

--- a/README.md
+++ b/README.md
@@ -13,18 +13,17 @@ Each directory contains an empty `.gitkeep` file so that it is tracked by Git ev
 
 ## Generating Order Templates
 
-Use `generate_order_template.py` with a JSON file that follows the
-
-structure documented in `order_generation/docs/order_template.md`. The JSON lists every
-yellow cell from the Excel template with its label (`key`) and the value
-to write. The script fills those cells in `order_generation/docs/empty_base_template.xlsx`
-and inserts product rows. Green cells contain formulas that compute totals
-automatically.
+Use `PO_excel.py` with a JSON file that follows the structure documented in
+`order_generation/docs/order_template.md`. The JSON lists every yellow cell from
+the Excel template with its label (`key`) and the value to write. The script
+verifies that each cell reference matches the labels in
+`order_generation/docs/empty_base_template.xlsx`, fills those cells, and inserts
+product rows. Green cells contain formulas that compute totals automatically.
 An example JSON file is provided in `order_generation/docs/order_template_example.json`.
 
 When generating the spreadsheet the script inserts any image referenced in the
-`产品图片` field of each product row. The value should be a path to the image
-file on disk.  The product name (`产品名称`) is automatically prepended to the
+`产品图片` field of each product row. The value should be a path to the image file
+on disk. The product name (`产品名称`) is automatically prepended to the
 description when filling the "描述" column.
 
 
@@ -67,11 +66,10 @@ Follow these steps to generate the purchase order:
      the `products` list and combining the `cells` section by selecting the
      most appropriate value for each cell.
 4. Ensure that `order_generation/docs/empty_base_template.xlsx` matches the
-   cell addresses used in the JSON templates. If they do not match,
-   update `generate_order_template.py` accordingly.
-5. Run `generate_order_template.py` to fill the spreadsheet(s). The script
-   defaults to `empty_base_template.xlsx` and writes the values from the JSON
-   file.
+   cell addresses used in the JSON templates. If they do not match, update
+   `PO_excel.py` accordingly.
+5. Run `PO_excel.py` to fill the spreadsheet(s). The script defaults to
+   `empty_base_template.xlsx` and writes the values from the JSON file.
 6. Review the generated Excel file(s) manually and fix any remaining issues.
 
 This process keeps products from different factories on separate spreadsheets

--- a/order_generation/docs/order_template.md
+++ b/order_generation/docs/order_template.md
@@ -1,12 +1,13 @@
 # Order Template Format
 
 The order template is an Excel workbook that already contains most of the layout
-and formulas.  Only the yellow cells in `template_order_excel_1.xlsx` are meant
-to be filled from JSON.  Green cells contain formulas and will be calculated by
+and formulas. Only the yellow cells in `empty_base_template.xlsx` are meant to
+be filled from JSON. Green cells contain formulas and will be calculated by
 Excel automatically.
 
-`generate_order_template.py` reads a JSON file and writes the values into the
-corresponding yellow cells before inserting the product rows.
+`PO_excel.py` reads a JSON file, verifies that the cell references match the
+labels in the template, and writes the values into the corresponding yellow
+cells before inserting the product rows.
 
 ## JSON Structure
 
@@ -35,7 +36,7 @@ corresponding yellow cells before inserting the product rows.
 
 - **cells** – mapping of Excel cell addresses to objects containing ``key`` and
   ``value``. Every yellow cell from the template is included even if the value
-  is empty. `template_order_excel_1.xlsx` contains 47 yellow cells and the
+  is empty. `empty_base_template.xlsx` contains 47 yellow cells and the
   example lists them all.
 - **products** – list of product rows inserted starting at row 7. The amount
   column is calculated automatically with a formula.
@@ -50,7 +51,7 @@ When a purchase order (PO) spreadsheet cannot be parsed automatically, you can
 fill out the JSON file by hand using the data in that PO:
 
 1. Open the PO `.xlsx` file and locate every field that maps to a yellow cell in
-   `template_order_excel_1.xlsx`.
+   `empty_base_template.xlsx`.
 2. Copy the text from each cell directly into the corresponding `value` in the
    JSON. **Do not change the keys** and make sure every field from the template
    appears in the JSON even if the value is empty.
@@ -69,5 +70,5 @@ fill out the JSON file by hand using the data in that PO:
 4. Complete the `footer` section with the buyer and supplier information from the
    bottom of the PO spreadsheet.
 
-After the JSON is prepared you can run `generate_order_template.py` to populate
-`template_order_excel_1.xlsx` with the PO data.
+After the JSON is prepared you can run `PO_excel.py` to populate
+`empty_base_template.xlsx` with the PO data.


### PR DESCRIPTION
## Summary
- Replace generate_order_template.py with PO_excel.py to build purchase orders from JSON
- Verify template cell labels and automatically grow product table
- Update docs to reference the new workflow

## Testing
- `python -m py_compile amazon_order/PO_excel.py`
- `python amazon_order/PO_excel.py amazon_order/order_generation/docs/order_template_example_blank.json /tmp/test.xlsx` *(fails: ModuleNotFoundError: No module named 'openpyxl')*
- `pip install openpyxl` *(fails: Could not find a version that satisfies the requirement openpyxl)*

------
https://chatgpt.com/codex/tasks/task_b_688c12bf75e8832fa9e15985377ebb29