### PR TITLE
Add script to populate PO Excel from JSON

### DIFF
--- a/order_generation/json_PO_excel.py
+++ b/order_generation/json_PO_excel.py
@@ -1,0 +1,66 @@
+import sys
+import json
+from pathlib import Path
+
+try:
+    from openpyxl import load_workbook
+except ModuleNotFoundError as exc:  # pragma: no cover - dependency missing in tests
+    raise SystemExit("openpyxl is required to run this script") from exc
+
+PRODUCT_START_ROW = 7
+COLUMN_MAP = {
+    '产品编号': 'A',
+    '产品图片': 'B',
+    '描述': 'C',
+    '数量/个': 'D',
+    '单价': 'E',
+    '包装方式': 'G',
+}
+
+
+def fill_workbook(template: Path, data: dict):
+    """Return workbook filled with ``data`` using ``template``."""
+    wb = load_workbook(template)
+    ws = wb.active
+
+    for addr, info in data.get('cells', {}).items():
+        ws[addr] = info.get('value', '')
+
+    row = PRODUCT_START_ROW
+    for product in data.get('products', []):
+        for key, col in COLUMN_MAP.items():
+            if key in product:
+                ws[f"{col}{row}"] = product[key]
+        qty = product.get('数量/个')
+        price = product.get('单价')
+        if qty not in (None, '') and price not in (None, ''):
+            ws[f"F{row}"] = f"=D{row}*E{row}"
+        row += 1
+
+    footer = data.get('footer', {})
+    if 'buyer' in footer:
+        ws['B69'] = footer['buyer']
+    if 'supplier' in footer:
+        ws['E69'] = footer['supplier']
+    return wb
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print("usage: json_PO_excel.py <input.json> <output.xlsx>")
+        return 1
+
+    json_path = Path(argv[1])
+    out_path = Path(argv[2])
+    template = Path(__file__).resolve().parent / 'docs' / 'empty_base_template.xlsx'
+
+    with open(json_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    wb = fill_workbook(template, data)
+    wb.save(out_path)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- add `json_PO_excel.py` to load JSON order data into `empty_base_template.xlsx`

## Testing
- `python -m py_compile order_generation/json_PO_excel.py`
- `python order_generation/json_PO_excel.py order_generation/docs/order_template_example_blank.json /tmp/output.xlsx` *(fails: openpyxl is required)*

------
https://chatgpt.com/codex/tasks/task_b_688c367c275c832fb47b60775c67f4a2