### PR TITLE
Add JSON template merging utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ Sometimes an order request only specifies a SKU and quantity, for example:
 3. Decide whether the items originate from one factory or several:
    - **Different factories** – keep the templates separate and create one Excel
      file per factory.
-   - **Same factory** – merge the JSON data by appending every entry to the
-     `products` list and merging the `cells` section, choosing the most
-     appropriate value for each cell.
+   - **Same factory** – use `order_generation/merge_json_templates.py` to merge
+     the JSON data. The script appends every entry to the `products` list and
+     chooses the most appropriate value for each cell in the merged `cells`
+     section.
 4. For each factory group, run `json_PO_excel.py` to write the JSON values into
    `order_generation/docs/empty_base_template.xlsx`.
 5. Confirm that the populated `empty_base_template.xlsx` matches the cell

--- a/order_generation/merge_json_templates.py
+++ b/order_generation/merge_json_templates.py
@@ -1,0 +1,79 @@
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _select_cell(existing: Dict[str, Any], new: Dict[str, Any], addr: str) -> Dict[str, Any]:
+    """Return preferred cell info between ``existing`` and ``new``.
+
+    Preference is given to the first non-empty value encountered. When both
+    values are present and conflict, the original value is kept and a message
+    is printed to stderr so the caller can review the decision.
+    """
+    if not existing or not existing.get("value"):
+        return new
+    if new.get("value") and new["value"] != existing.get("value"):
+        print(
+            f"conflicting value for cell {addr}: "
+            f"keeping {existing['value']!r} and ignoring {new['value']!r}",
+            file=sys.stderr,
+        )
+    return existing
+
+
+def merge_json_templates(paths: List[Path]) -> Dict[str, Any]:
+    """Merge product JSON templates for a single factory.
+
+    The first file acts as the base. Subsequent files have their ``products``
+    appended and their ``cells`` merged using :func:`_select_cell` to choose the
+    most appropriate value when conflicts arise.
+    """
+    if not paths:
+        raise ValueError("at least one input path is required")
+
+    with open(paths[0], "r", encoding="utf-8") as f:
+        merged: Dict[str, Any] = json.load(f)
+
+    merged.setdefault("products", [])
+    merged.setdefault("cells", {})
+    merged.setdefault("footer", {})
+
+    for path in paths[1:]:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        merged["products"].extend(data.get("products", []))
+
+        cells = data.get("cells", {})
+        for addr, info in cells.items():
+            merged["cells"][addr] = _select_cell(merged["cells"].get(addr), info, addr)
+
+        footer = data.get("footer", {})
+        for key, value in footer.items():
+            if key not in merged["footer"] or not merged["footer"][key]:
+                merged["footer"][key] = value
+
+    return merged
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) < 4:
+        print(
+            "usage: merge_json_templates.py <output.json> <input1.json> <input2.json> [input3.json ...]"
+        )
+        return 1
+
+    out_path = Path(argv[1])
+    in_paths = [Path(p) for p in argv[2:]]
+
+    merged = merge_json_templates(in_paths)
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- add `merge_json_templates.py` to combine SKU JSON templates by factory, merging product lists and resolving cell conflicts
- document new merge step in direct SKU handling instructions

## Testing
- `python -m py_compile order_generation/merge_json_templates.py`
- `python order_generation/merge_json_templates.py /tmp/merged.json order_generation/json_template/48-82P3-QSFG.json order_generation/json_template/2EC-Green.json`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c4d4a1238832fbf7d94f9c3ce320b