### PR TITLE
Build parent-child mapping from ASIN data

### DIFF
--- a/order_generation/docs/parent_child_mapping.json
+++ b/order_generation/docs/parent_child_mapping.json
@@ -1,34 +1,180 @@
 {
   "parents": {
-    "B10-MJB2": {
+    "Elasticbrush01": {
+      "name": "ecoed 可降解绿色鱼骨梳",
+      "children": [
+        "Elasticbrush01",
+        "Elasticbrush05",
+        "Elasticbrush02",
+        "Elasticbrush06"
+      ]
+    },
+    "EC404": {
+      "name": "Ecoed洗头刷绿色单只装细针",
+      "children": [
+        "EC404",
+        "ZW-YI7D-KWFL",
+        "7S-HA5T-5D0X",
+        "2EC-Green",
+        "EC405-1-Pink",
+        "5V-GW44-8VVX",
+        "2EC-Blue",
+        "2EC-Pink",
+        "2EC-Yellow"
+      ]
+    },
+    "ST1122-1": {
+      "name": "norsewood棕黑色气垫梳8.5*24.5*1.3",
+      "children": [
+        "ST1122-1",
+        "ST1122-3"
+      ]
+    },
+    "B10-MJB2-BK": {
       "name": "木头脚挫2只装 Foot Scraper Pedicure Foot File, Professional Foot Rasp File Foot Scrubber, Premium Callus Remover for Feet to Remove Dead Skin, Hard Skin, Cracked Heels, Perfect Foot Care Pedicure Tools (2 Pack)",
       "children": [
         "B10-MJB2-BK",
         "B10-MJB2-BK2"
       ]
     },
-    "B10-JMY802": {
-      "name": "洗脸仪",
-      "children": [
-        "B10-JMY802-BU",
-        "B10-JMY802-PK"
-      ]
-    },
-    "B10-MJQ1": {
+    "B10-MJQ1-BU": {
       "name": "电动磨脚器",
       "children": [
         "B10-MJQ1-BU",
         "B10-MJQ1-PK"
       ]
     },
-    "B10-ZMS3D": {
-      "name": "bass同款",
+    "EERB2.11.3": {
+      "name": "ellen evyse黑色弹性漆铝筒2只装2.1/1.3in",
       "children": [
-        "B10-ZMS3D-BR",
-        "B10-ZMS3D-NEW"
+        "EERB2.11.3",
+        "EERB2.11.7"
       ]
     },
-    "B10-TJ2": {
+    "EC-5001": {
+      "name": "ECOED粉色指甲钳套装新22",
+      "children": [
+        "EC-5001",
+        "B10-ZJJ5-PK"
+      ]
+    },
+    "ECSB-2Green": {
+      "name": "Ecoed洗头刷绿色组合装",
+      "children": [
+        "ECSB-2Green",
+        "ECSB-2Blue",
+        "EC405-3-Grey",
+        "EC405-3-Pink",
+        "EC405-3-Green",
+        "EC405-1-Blue"
+      ]
+    },
+    "EC403-3": {
+      "name": "Ecoed绿色浴刷",
+      "children": [
+        "EC403-3",
+        "EC403-2",
+        "EC403"
+      ]
+    },
+    "BB101-2": {
+      "name": "boxxbrush盒子梳玫红色",
+      "children": [
+        "BB101-2",
+        "BB101-3"
+      ]
+    },
+    "EC04-GREEN": {
+      "name": "化妆刷套装GREEN",
+      "children": [
+        "EC04-GREEN",
+        "EC04-NATURAL"
+      ]
+    },
+    "EC-D1-PINK": {
+      "name": "化妆刷大头 PINK",
+      "children": [
+        "EC-D1-PINK",
+        "EC-D1-CYAN",
+        "EC-D1-GREEN",
+        "EC-D1-NATURAL"
+      ]
+    },
+    "EC-X2-CYAN": {
+      "name": "化妆刷斜头CYAN",
+      "children": [
+        "EC-X2-CYAN",
+        "EC-X2-GREEN",
+        "EC-X2-PINK",
+        "EC-X2-NATURAL"
+      ]
+    },
+    "EC-P3-NATURAL": {
+      "name": "化妆刷平头NATURAL",
+      "children": [
+        "EC-P3-NATURAL",
+        "EC-P3-PINK",
+        "EC-P3-CYAN",
+        "EC-P3-GREEN"
+      ]
+    },
+    "FSC-WB02": {
+      "name": "FSC漂白榉木头梳(尼龙针)",
+      "children": [
+        "FSC-WB02",
+        "FSC-WB01"
+      ]
+    },
+    "C7524": {
+      "name": "黑色弹性漆铝筒35cm",
+      "children": [
+        "C7524",
+        "C7522",
+        "C7523"
+      ]
+    },
+    "Elasticbrush05": {
+      "name": "ecoed 可降解蓝色鱼骨梳",
+      "children": [
+        "Elasticbrush05",
+        "Elasticbrush06",
+        "Elasticbrush04",
+        "Elasticbrush03",
+        "Elasticbrush02",
+        "Elasticbrush01"
+      ]
+    },
+    "large": {
+      "name": "ecoed 陶瓷漆铝筒 1.3寸&2.1寸",
+      "children": [
+        "large",
+        "small",
+        "NF-NTN3-LC5B",
+        "OV-GAQM-PFGI"
+      ]
+    },
+    "3I-OEE1-VHAB": {
+      "name": "可降解树叶梳（粉色）",
+      "children": [
+        "3I-OEE1-VHAB",
+        "0L-REVP-RPUM"
+      ]
+    },
+    "B10-HB04-ADULTBU": {
+      "name": "4只装头梳",
+      "children": [
+        "B10-HB04-ADULTBU",
+        "B10-QDS2-GN"
+      ]
+    },
+    "ZJ22": {
+      "name": "木板纸巾架长",
+      "children": [
+        "ZJ22",
+        "ZJ21"
+      ]
+    },
+    "B10-TJ2-12": {
       "name": "金属支架12寸",
       "children": [
         "B10-TJ2-12",
@@ -36,135 +182,26 @@
         "B10-TJ2-20"
       ]
     },
-    "FSC": {
-      "name": "FSC漂白榉木头梳（木针）",
+    "B10-KJJ2-WT": {
+      "name": "可降解两只灰色",
       "children": [
-        "FSC-WB01",
-        "FSC-WB02"
+        "B10-KJJ2-WT",
+        "B10-KJJYZ-WT"
       ]
     },
-    "ST1122": {
-      "name": "norsewood棕黑色气垫梳8.5*24.5*1.3",
+    "AMCB-Blue": {
+      "name": "卷发定型梳蓝色",
       "children": [
-        "ST1122-1",
-        "ST1122-3"
-      ]
-    },
-    "EC403": {
-      "name": "Ecoed咖啡渣浴刷",
-      "children": [
-        "EC403",
-        "EC403-2",
-        "EC403-3"
-      ]
-    },
-    "EC": {
-      "name": "ECOED粉色指甲钳套装新22",
-      "children": [
-        "EC-5001",
-        "EC-ZZ01"
-      ]
-    },
-    "EC04": {
-      "name": "化妆刷套装GREEN",
-      "children": [
-        "EC04-GREEN",
-        "EC04-NATURAL"
-      ]
-    },
-    "EC-D1": {
-      "name": "化妆刷大头 PINK",
-      "children": [
-        "EC-D1-PINK",
-        "EC-D1-GREEN",
-        "EC-D1-NATURAL",
-        "EC-D1-CYAN"
-      ]
-    },
-    "EC-P3": {
-      "name": "化妆刷平头PINK",
-      "children": [
-        "EC-P3-PINK",
-        "EC-P3-GREEN",
-        "EC-P3-NATURAL",
-        "EC-P3-CYAN"
-      ]
-    },
-    "EC-X2": {
-      "name": "化妆刷斜头PINK",
-      "children": [
-        "EC-X2-PINK",
-        "EC-X2-GREEN",
-        "EC-X2-NATURAL",
-        "EC-X2-CYAN"
-      ]
-    },
-    "2EC": {
-      "name": "Ecoed洗头刷粉色两只装细针",
-      "children": [
-        "2EC-Pink",
-        "2EC-Blue",
-        "2EC-Green",
-        "2EC-Yellow"
-      ]
-    },
-    "BB101": {
-      "name": "boxxbrush盒子梳玫红色",
-      "children": [
-        "BB101-2",
-        "BB101-3"
-      ]
-    },
-    "EC405-1": {
-      "name": "ecoed 洗头刷405单只装蓝色粗针",
-      "children": [
-        "EC405-1-Blue",
-        "EC405-1-Green",
-        "EC405-1-Pink",
-        "EC405-1-Grey"
-      ]
-    },
-    "EC405-2": {
-      "name": "ecoed 洗头刷405两只装蓝色粗针",
-      "children": [
-        "EC405-2-Blue",
-        "EC405-2-Green",
-        "EC405-2-Pink",
-        "EC405-2-Grey"
-      ]
-    },
-    "EC405-3": {
-      "name": "ecoed 洗头刷405单只装蓝色50硬",
-      "children": [
-        "EC405-3-Blue",
-        "EC405-3-Green",
-        "EC405-3-Pink",
-        "EC405-3-Grey"
-      ]
-    },
-    "ECSB": {
-      "name": "Ecoed洗头刷绿色组合装",
-      "children": [
-        "ECSB-2Green",
-        "ECSB-2Blue",
-        "ECSB-TPR1"
-      ]
-    },
-    "NW": {
-      "name": "norsewood灰色榉木气垫猪鬃梳（bass）",
-      "children": [
-        "NW-GRAY1",
-        "NW-GRAY2",
-        "NW-GRAY3"
-      ]
-    },
-    "AMCB": {
-      "name": "尼龙卷发定型梳(蓝色)",
-      "children": [
-        "AMCB-black",
-        "AMCB-Pink",
         "AMCB-Blue",
-        "AMCB-01"
+        "AMCB-Pink"
+      ]
+    },
+    "ZW-YI7D-KWFL": {
+      "name": "Ecoed洗头刷蓝色单只装细针",
+      "children": [
+        "ZW-YI7D-KWFL",
+        "7S-HA5T-5D0X",
+        "5V-GW44-8VVX"
       ]
     }
   }

--- a/order_generation/generate_parent_child_mapping.py
+++ b/order_generation/generate_parent_child_mapping.py
@@ -1,7 +1,55 @@
 import json
 import sys
+import zipfile
+import xml.etree.ElementTree as ET
 from typing import Dict, Any
-from excel_to_json import read_rows
+
+NAMESPACE = '{http://schemas.openxmlformats.org/spreadsheetml/2006/main}'
+
+
+def read_rows(xlsx: str):
+    """Return list of rows from the first worksheet of ``xlsx``.
+
+    Only standard library modules are used to avoid external dependencies."""
+    with zipfile.ZipFile(xlsx) as z:
+        shared: list[str] = []
+        if 'xl/sharedStrings.xml' in z.namelist():
+            root = ET.fromstring(z.read('xl/sharedStrings.xml'))
+            for si in root.findall('.//' + NAMESPACE + 'si'):
+                text = ''.join(t.text or '' for t in si.findall('.//' + NAMESPACE + 't'))
+                shared.append(text)
+        sheet_root = ET.fromstring(z.read('xl/worksheets/sheet1.xml'))
+        rows_maps = []
+        max_col = 0
+        for row in sheet_root.findall('.//' + NAMESPACE + 'row'):
+            row_map: Dict[int, str] = {}
+            for c in row.findall(NAMESPACE + 'c'):
+                addr = c.get('r')
+                col_letters = ''.join(ch for ch in addr if ch.isalpha())
+                col_idx = 0
+                for ch in col_letters:
+                    col_idx = col_idx * 26 + ord(ch) - 64
+                col_idx -= 1
+                t = c.get('t')
+                if t == 's':
+                    v = c.find(NAMESPACE + 'v')
+                    val = shared[int(v.text)] if v is not None else ''
+                elif t == 'inlineStr':
+                    is_elem = c.find(NAMESPACE + 'is')
+                    val = ''.join(
+                        tn.text or '' for tn in is_elem.findall('.//' + NAMESPACE + 't')
+                    ) if is_elem is not None else ''
+                else:
+                    v = c.find(NAMESPACE + 'v')
+                    val = v.text if v is not None else ''
+                row_map[col_idx] = val
+                if col_idx > max_col:
+                    max_col = col_idx
+            rows_maps.append(row_map)
+        rows = []
+        for row_map in rows_maps:
+            rows.append([row_map.get(i, '') for i in range(max_col + 1)])
+        return rows
 
 
 def build_mapping(xlsx: str) -> Dict[str, Any]:
@@ -9,32 +57,33 @@ def build_mapping(xlsx: str) -> Dict[str, Any]:
     if not rows:
         return {"parents": {}}
     header = rows[0]
-    try:
-        sku_idx = header.index('*SKU')
-    except ValueError:
-        raise ValueError('SKU column "*SKU" not found')
+    sku_idx = header.index('SKU')
+    parent_asin_idx = header.index('父ASIN')
     name_idx = header.index('品名') if '品名' in header else None
-    mapping: Dict[str, Dict[str, Any]] = {}
+    groups: Dict[str, Dict[str, Any]] = {}
     for row in rows[1:]:
-        if sku_idx >= len(row):
+        if len(row) <= max(sku_idx, parent_asin_idx):
             continue
         sku = row[sku_idx].strip()
-        if not sku:
+        parent_asin = row[parent_asin_idx].strip()
+        name = row[name_idx].strip() if name_idx is not None and len(row) > name_idx else ''
+        if not sku or not parent_asin:
             continue
-        name = row[name_idx].strip() if name_idx is not None and name_idx < len(row) else ''
-        if '-' in sku:
-            parent = sku.rsplit('-', 1)[0]
-        else:
-            parent = sku
-        entry = mapping.setdefault(parent, {"name": name, "children": []})
-        if not entry["name"]:
-            entry["name"] = name
-        entry["children"].append(sku)
-    mapping = {p: v for p, v in mapping.items() if len(v["children"]) > 1}
-    return {"parents": mapping}
+        group = groups.setdefault(parent_asin, {"name": name, "skus": []})
+        if not group["name"] and name:
+            group["name"] = name
+        if sku not in group["skus"]:
+            group["skus"].append(sku)
+    parents: Dict[str, Dict[str, Any]] = {}
+    for info in groups.values():
+        skus = info["skus"]
+        if len(skus) > 1:
+            parent_sku = skus[0]
+            parents[parent_sku] = {"name": info["name"], "children": skus}
+    return {"parents": parents}
 
 
-def main():
+def main() -> int:
     if len(sys.argv) != 3:
         print('usage: generate_parent_child_mapping.py <input.xlsx> <output.json>')
         return 1


### PR DESCRIPTION
## Summary
- derive parent-child SKU relationships from ASIN/父ASIN pairs using pure stdlib
- regenerate parent_child_mapping.json based on the updated grouping logic

## Testing
- `python order_generation/generate_parent_child_mapping.py order_generation/docs/asin_parent_sku.xlsx order_generation/docs/parent_child_mapping.json`


------
https://chatgpt.com/codex/tasks/task_b_6890156f3bf8832f8eeeda252b548d52